### PR TITLE
[core] First set of DB primitives

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,6 +1,7 @@
 -- TODO:
 -- * Do we want a `participants.updated_at` column and add a UPDATE trigger?
 -- * Are Teams user IDs the same as Graph user IDs?
+-- * Add unique constraints to UUIDs
 
 DROP TABLE IF EXISTS standups_participants;
 DROP TABLE IF EXISTS participants;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,8 +1,48 @@
-import { Client } from "pg";
+import { Client as DBClient } from "pg";
 
-export async function answer(client: Client) {
-  const res = await client.query(
-    'SELECT "teams_id" as "teamsID" FROM participants'
+/**
+ * @param dbClient
+ * @param setOfParticipantIDs
+ * @returns The ID of the standup record
+ */
+export async function createParticipantSet(
+  dbClient: DBClient,
+  setOfParticipantIDs: number[]
+): Promise<number> {
+  try {
+    await dbClient.query("BEGIN");
+    const standupID = (
+      await dbClient.query(`
+        INSERT INTO standups DEFAULT VALUES RETURNING id
+      `)
+    ).rows[0].id;
+    await Promise.all(
+      setOfParticipantIDs.map((participantID) => {
+        return dbClient.query(
+          `
+          INSERT INTO standups_participants(standup_id, participant_id) VALUES($1, $2)
+        `,
+          [standupID, participantID]
+        );
+      })
+    );
+    await dbClient.query("COMMIT");
+    return standupID;
+  } catch (error) {
+    await dbClient.query("ROLLBACK");
+    throw error;
+  }
+}
+
+export async function getParticipantSet(
+  dbClient: DBClient,
+  standupID: number
+): Promise<number[]> {
+  const result = await dbClient.query(
+    `
+    SELECT participant_id FROM standups_participants WHERE standups_participants.standup_id = $1
+  `,
+    [standupID]
   );
-  return res.rows[0].teamsID;
+  return result.rows.map((row) => row.participant_id);
 }


### PR DESCRIPTION
Allows the creation of a standup (a participants set) and fetching the participants in a standup.

Not the DRYest code, but we can clean that up later on.